### PR TITLE
feat: add dry run/preview mode for safe file removal operations

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,13 +1,13 @@
 {
-  "name": "sysremvr",
+  "name": "mac-rmvr",
   "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "sysremvr",
+      "name": "mac-rmvr",
       "version": "1.0.0",
-      "license": "ISC",
+      "license": "MIT",
       "dependencies": {
         "pretty-bytes": "^6.1.1"
       }


### PR DESCRIPTION
Key changes here:
- Add `--dry-run` flag to CLI options
- Implement `dryRun` mode in `MacOSCleaner` class
- Show preview of files that would be removed
- Display size of files that would be freed

This allows users to preview file deletion operations before finally executing them.

This is how:
<img width="677" alt="Screenshot 2025-01-02 at 7 48 57 PM" src="https://github.com/user-attachments/assets/2eea9322-3170-495a-92b2-6a884db491df" />

Here, the output tells us:

✅ The `dry run` flag is detected (DRY RUN message)
✅ It correctly resolves the path (expanded ~ to /Users/mac)
✅ It finds the file and calculates its size (13 bytes)
✅ Most importantly: the file isn't actually deleted
